### PR TITLE
Fix configuration loading for StudyBot

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ A comprehensive web application that helps students chat with specialized AI tut
    ```
    key:your-api-key-here
    model:your-model-name-here
+   baseURL:https://api.example.com/v1
    ```
+   StudyBot reads this file on startup, so ensure it is served from the same directory as `index.html`.
 
 3. **Serve Files**: Use a local web server to serve the files:
    ```bash

--- a/app.js
+++ b/app.js
@@ -65,8 +65,26 @@ class StudyBotApp {
     async loadConfig() {
         console.log('Loading configuration...');
         try {
-            // Config is already set in constructor
-            console.log('Using default configuration');
+            const response = await fetch('config.txt');
+            if (response.ok) {
+                const text = await response.text();
+                text.split(/\n+/).forEach(line => {
+                    const [key, value] = line.split(':');
+                    if (!key || !value) return;
+                    const k = key.trim();
+                    const v = value.trim();
+                    if (k === 'key') {
+                        this.config.apiKey = v;
+                    } else if (k === 'model') {
+                        this.config.model = v;
+                    } else if (k === 'baseURL') {
+                        this.config.baseURL = v;
+                    }
+                });
+                console.log('Configuration loaded from file');
+            } else {
+                console.log('Config file not found - using defaults');
+            }
         } catch (error) {
             console.error('Error loading config:', error);
         }

--- a/config.txt
+++ b/config.txt
@@ -1,2 +1,3 @@
 key:sk-UVKYLhiNf0MKXRqbnDiehA
 model:Meta-Llama-4-Maverick-17B-128E-Instruct-FP8
+baseURL:https://api.akash.network/v1


### PR DESCRIPTION
## Summary
- load API configuration from `config.txt`
- document base URL in README
- fix `config.txt` formatting

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ca565aa20832e8cb6d12591837030